### PR TITLE
Set environment variable LANG=C.UTF-8

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,7 @@ FROM ubuntu:22.04
 # Install APT packages
 # Note: git is actually not needed in this image, but it might be useful for
 # users to have it installed (to clone/push/diff projects or libraries).
-ENV DEBIAN_FRONTEND=noninteractive
+ARG DEBIAN_FRONTEND=noninteractive
 RUN apt-get update -q && apt-get -y -q install --no-install-recommends \
     ca-certificates git libfontconfig1 libglib2.0-0 libglu1-mesa wget xvfb \
   && rm -rf /var/lib/apt/lists/*

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,11 @@
 FROM ubuntu:22.04
 
+# Make sure UTF-8 characters printed by librepcb-cli are displayed properly.
+# For a different language of the output of librepcb-cli, the environment
+# variable LANG can be overridden at container runtime with the '-e' flag.
+# Note: Not using LC_ALL since it leads to a runtime warning printed to stderr.
+ENV LANG=C.UTF-8
+
 # Install APT packages
 # Note: git is actually not needed in this image, but it might be useful for
 # users to have it installed (to clone/push/diff projects or libraries).


### PR DESCRIPTION
Fixes broken unicode characters in the `stdout`/`stderr` of `librepcb-cli`.